### PR TITLE
Correctness fixes

### DIFF
--- a/examples/tutorial/tutorial.cpp
+++ b/examples/tutorial/tutorial.cpp
@@ -68,7 +68,7 @@ TEST_CASE("Calling f_surrogate") {
 
     f_surrogate
         .bind_original_function([&](){ result = f(x,y,z); })      // [6]
-        .bind_all_callsite_vars(&x, &y, &z);                      // [7]
+        .bind_all_callsite_vars(&x, &y, &z, &result);                      // [7]
 
     x = 1; y = 1; z = 1;
     f_surrogate.call_original_and_capture();
@@ -106,7 +106,7 @@ TEST_CASE("Calling f_surrogate") {
 
 
 // We can create a wrapper function for f like so:
-
+#if 0
 double f_wrapper(double x, double y, double z) {
     double result = 0.0;
     f_surrogate.bind_original_function([&](){ result = f(x,y,z); })      // [5]
@@ -188,7 +188,6 @@ void zero_top_right(T* arr, int nrows, int ncols) {
 }
 
 
-
 TEST_CASE("Surrogates with array input data") {
 
     float matrix[] = { 1,  2,  3,  4,  5,
@@ -236,3 +235,5 @@ TEST_CASE("Surrogates with array input data") {
 
 // Global variables
 // Arrays of structs of structs of arrays of data
+
+#endif

--- a/examples/tutorial/tutorial.cpp
+++ b/examples/tutorial/tutorial.cpp
@@ -106,11 +106,11 @@ TEST_CASE("Calling f_surrogate") {
 
 
 // We can create a wrapper function for f like so:
-#if 0
+
 double f_wrapper(double x, double y, double z) {
     double result = 0.0;
     f_surrogate.bind_original_function([&](){ result = f(x,y,z); })      // [5]
-               .bind_all_callsite_vars(&x, &y, &z)                       // [6]
+               .bind_all_callsite_vars(&x, &y, &z, &result)              // [6]
                .call();                                                  // [7]
     return result;
 }
@@ -232,8 +232,5 @@ TEST_CASE("Surrogates with array input data") {
 
 }
 
-
 // Global variables
 // Arrays of structs of structs of arrays of data
-
-#endif

--- a/surrogate/include/surrogate_builder.h
+++ b/surrogate/include/surrogate_builder.h
@@ -81,8 +81,8 @@ struct Cursor<HeadT> {
     SurrogateBuilder* builder = nullptr;
 
     Cursor(OpticBase* o, std::shared_ptr<CallSiteVariable> csv, SurrogateBuilder* builder);
-    Cursor<HeadT> primitive(std::string name, Direction dir=Direction::IN);
-    Cursor<HeadT> primitives(std::string name, std::vector<int64_t>&& shape, Direction dir=Direction::IN);
+    Cursor<HeadT> primitive(std::string name, Direction dir=Direction::IN, DType dtype= default_dtype<HeadT>());
+    Cursor<HeadT> primitives(std::string name, std::vector<int64_t>&& shape, Direction dir=Direction::IN, DType dtype= default_dtype<HeadT>());
     Cursor<HeadT> array(size_t size);
     SurrogateBuilder& end();
 
@@ -98,8 +98,8 @@ struct Cursor {
     SurrogateBuilder* builder = nullptr;
 
     Cursor(OpticBase* focus, std::shared_ptr<CallSiteVariable> callsite_var, SurrogateBuilder* builder);
-    Cursor<HeadT, RestTs...> primitive(std::string name, Direction dir=Direction::IN);
-    Cursor<HeadT, RestTs...> primitives(std::string name, std::vector<int64_t>&& shape, Direction dir=Direction::IN);
+    Cursor<HeadT, RestTs...> primitive(std::string name, Direction dir=Direction::IN, DType dtype= default_dtype<HeadT>());
+    Cursor<HeadT, RestTs...> primitives(std::string name, std::vector<int64_t>&& shape, Direction dir=Direction::IN, DType dtype= default_dtype<HeadT>());
     Cursor<HeadT, RestTs...> array(size_t size);
     Cursor<RestTs...> end();
 
@@ -149,13 +149,13 @@ template<typename HeadT>
 Cursor<HeadT>::Cursor(OpticBase*, std::shared_ptr<CallSiteVariable> c, SurrogateBuilder *b) : current_callsite_var(c), builder(b) {}
 
 template<typename HeadT>
-Cursor<HeadT> Cursor<HeadT>::primitive(std::string name, Direction dir) {
-    return primitives(name, {}, dir);
+Cursor<HeadT> Cursor<HeadT>::primitive(std::string name, Direction dir, DType dtype) {
+    return primitives(name, {}, dir, dtype);
 }
 
 template<typename HeadT>
-Cursor<HeadT> Cursor<HeadT>::primitives(std::string name, std::vector<int64_t> &&shape, Direction dir) {
-    auto child = new TensorIso<HeadT>(std::move(shape));
+Cursor<HeadT> Cursor<HeadT>::primitives(std::string name, std::vector<int64_t> &&shape, Direction dir, DType dtype) {
+    auto child = new TensorIso<HeadT>(std::move(shape), dtype);
     child->name = name;
     child->is_leaf = true;
     current_callsite_var->optics_tree.push_back(child->clone());
@@ -199,13 +199,13 @@ Cursor<HeadT, RestTs...>::Cursor(OpticBase* focus, std::shared_ptr<CallSiteVaria
 : focus(focus), current_callsite_var(callsite_var), builder(builder) {}
 
 template <typename HeadT, typename... RestTs>
-Cursor<HeadT, RestTs...> Cursor<HeadT, RestTs...>::primitive(std::string name, Direction dir) {
-    return primitives(name, {}, dir);
+Cursor<HeadT, RestTs...> Cursor<HeadT, RestTs...>::primitive(std::string name, Direction dir, DType dtype) {
+    return primitives(name, {}, dir, dtype);
 }
 
 template <typename HeadT, typename... RestTs>
-Cursor<HeadT, RestTs...> Cursor<HeadT, RestTs...>::primitives(std::string name, std::vector<int64_t>&& shape, Direction dir) {
-    auto child = new TensorIso<HeadT>(std::move(shape));
+Cursor<HeadT, RestTs...> Cursor<HeadT, RestTs...>::primitives(std::string name, std::vector<int64_t>&& shape, Direction dir, DType dtype) {
+    auto child = new TensorIso<HeadT>(std::move(shape), dtype);
     child->name = name;
     child->is_leaf = true;
     focus->unsafe_attach(child);

--- a/surrogate/include/tensor.hpp
+++ b/surrogate/include/tensor.hpp
@@ -23,7 +23,7 @@ enum class DType { Undefined, UI8, I16, I32, I64, F32, F64 };
 // https://pytorch.org/docs/stable/tensor_attributes.html
 
 template <typename T>
-phasm::DType dtype() {
+phasm::DType default_dtype() {
     if (std::is_same<T, uint8_t>()) return phasm::DType::UI8;
     if (std::is_same<T, int16_t>()) return phasm::DType::I16;
     if (std::is_same<T, int32_t>()) return phasm::DType::I32;
@@ -32,6 +32,7 @@ phasm::DType dtype() {
     if (std::is_same<T, double>()) return phasm::DType::F64;
     return phasm::DType::Undefined;
 }
+
 
 void print_dtype(std::ostream& os, phasm::DType dtype);
 
@@ -83,7 +84,7 @@ public:
         // TODO: Clean up this mix of size_t's and int64_t's. Why is it this way?
         //   1. Torch uses _signed_ int64's for indices instead of size_t or ptrdiff_t
         //   2. PIN is very confused about size_t, long, and long long
-        m_dtype = dtype<T>();
+        m_dtype = default_dtype<T>();
     }
 
     // Construct tensor from buffer, taking ownership. This does NOT perform a copy.
@@ -92,7 +93,7 @@ public:
         m_data = data.release();
         m_length = length;
         m_shape = {static_cast<long>(length)};
-        m_dtype = dtype<T>();
+        m_dtype = default_dtype<T>();
     }
 
 
@@ -107,7 +108,7 @@ public:
         for (size_t i=0; i<m_length; ++i) buffer[i] = data[i];
         m_data = buffer;
         m_shape = shape;
-        m_dtype = dtype<T>();
+        m_dtype = default_dtype<T>();
     }
 
     // Construct tensor from buffer with shape information, e.g. a _contiguous_ tensor
@@ -119,7 +120,7 @@ public:
         }
         m_data = consecutive_buffer.release();
         m_shape = shape;
-        m_dtype = dtype<T>();
+        m_dtype = default_dtype<T>();
     }
 
     ~tensor();

--- a/torch_plugin/src/feedforward_model.cpp
+++ b/torch_plugin/src/feedforward_model.cpp
@@ -48,7 +48,7 @@ bool phasm::FeedForwardModel::infer() {
 
     size_t i = 0;
     for (const auto& output_model_var : m_outputs) {
-        output_model_var->inference_output = to_phasm_tensor(input_tensors[i++]);
+        output_model_var->inference_output = to_phasm_tensor(output_tensors[i++]);
     }
     return true;
 }

--- a/torch_plugin/src/torch_tensor_utils.cc
+++ b/torch_plugin/src/torch_tensor_utils.cc
@@ -46,11 +46,11 @@ phasm::tensor to_phasm_tensor_typed(const torch::Tensor& t) {
 phasm::tensor to_phasm_tensor(const torch::Tensor& t) {
     torch::Dtype dtype = t.dtype().toScalarType();
     if (dtype == torch::kUInt8) return to_phasm_tensor_typed<uint8_t>(t);
-    if (dtype == torch::kInt16) return to_phasm_tensor_typed<uint8_t>(t);
-    if (dtype == torch::kInt32) return to_phasm_tensor_typed<uint8_t>(t);
-    if (dtype == torch::kInt64) return to_phasm_tensor_typed<uint8_t>(t);
-    if (dtype == torch::kFloat32) return to_phasm_tensor_typed<uint8_t>(t);
-    if (dtype == torch::kFloat64) return to_phasm_tensor_typed<uint8_t>(t);
+    if (dtype == torch::kInt16) return to_phasm_tensor_typed<int16_t>(t);
+    if (dtype == torch::kInt32) return to_phasm_tensor_typed<int32_t>(t);
+    if (dtype == torch::kInt64) return to_phasm_tensor_typed<int64_t>(t);
+    if (dtype == torch::kFloat32) return to_phasm_tensor_typed<float>(t);
+    if (dtype == torch::kFloat64) return to_phasm_tensor_typed<double>(t);
     throw std::runtime_error("Torch tensor has invalid or incompatible dtype!");
 }
 

--- a/torch_plugin/src/torch_tensor_utils.cc
+++ b/torch_plugin/src/torch_tensor_utils.cc
@@ -40,7 +40,7 @@ phasm::tensor to_phasm_tensor_typed(const torch::Tensor& t) {
     for (size_t dim=0; dim<dims; ++dim) {
         phasm_dims.push_back(t.size(dim));
     }
-    return phasm::tensor(phasm_data, phasm_dims);
+    return phasm::tensor(std::unique_ptr<T[]>(phasm_data), phasm_dims);
 }
 
 phasm::tensor to_phasm_tensor(const torch::Tensor& t) {


### PR DESCRIPTION
* Rework how TensorIso handles dtypes
** TensorIso<T>::from() respects the input tensor dtype and converts it to T
** TensorIso<T>::to() converts T into a dtype of the user's choice
** DType can be set via the SurrogateBuilder

* Fix segfault with tutorial example (issue #13)
* Fix several fat-finger errors found along the way