### PR TITLE
Update loading-pt example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ PHASM_CALL_MODE=CaptureAndDump install/bin/phasm-example-pdesolver
 # Run vacuum tool against the example target program
 install/bin/phasm-memtrace-pin install/bin/phasm-example-memtrace
 ```
+
+A Google sheet to track the testing results: https://docs.google.com/spreadsheets/d/19iVKLKfVFlASZSgHDrYQx6XqakzqsAp0i52GIF5nEWs

--- a/docs/farm_guide.md
+++ b/docs/farm_guide.md
@@ -32,7 +32,7 @@ should be successful.
 ```bash
 Singularity> mkdir build && cd build
 Singularity> cmake -DCMAKE_PREFIX_PATH="$DEPS/libtorch;$DEPS/JANA2/install" -DLIBDWARF_DIR="$DEPS/libdwarf/installdir" \
- -DPIN_ROOT="$DEPS/pin" -DUSE_CUDA=ON..
+ -DPIN_ROOT="$DEPS/pin" -DUSE_CUDA=ON ..
 Singularity> make -j32 install
 ```
 

--- a/examples/loading_pt/CMakeLists.txt
+++ b/examples/loading_pt/CMakeLists.txt
@@ -2,7 +2,9 @@
 find_package(Torch REQUIRED)
 
 set(LOADING_PT_EXAMPLE_SOURCES loading_pt.cpp)
-add_executable(phasm-example-loading-pt
-        ${LOADING_PT_EXAMPLE_SOURCES})
-target_link_libraries(phasm-example-loading-pt "${TORCH_LIBRARIES}")
+add_executable(phasm-example-loading-pt ${LOADING_PT_EXAMPLE_SOURCES})
+set_target_properties(phasm-example-loading-pt PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+target_include_directories(phasm-example-loading-pt PUBLIC ${TORCH_INCLUDE_DIRS})
+target_link_libraries(phasm-example-loading-pt "${TORCH_LIBRARIES}" phasm-torch-plugin)
 install(TARGETS phasm-example-loading-pt DESTINATION bin)
+

--- a/examples/loading_pt/loading_pt.cpp
+++ b/examples/loading_pt/loading_pt.cpp
@@ -11,62 +11,50 @@
  * CUDA device is required. The test input tensor is of dimension (1256, 7, 6).
  */
 
-#include <torch/script.h>
-#include <ATen/cuda/CUDAContext.h>  // for cuda device properties
-#include <torch/torch.h>
+#include "torch_cuda_utils.h"
+#include "torchscript_model.h"
 
 #include <iostream>
 #include <memory>
 
-void print_cuda_device_info() {
-    cudaDeviceProp *cuda_prop = at::cuda::getCurrentDeviceProperties();
-    std::cout << "  CUDA device name: " << cuda_prop->name << std::endl;
-    std::cout << "  CUDA compute capacity: "
-              << cuda_prop->major << "." << cuda_prop->minor << std::endl;
-    std::cout << "  LibTorch version: "
-              << TORCH_VERSION_MAJOR << "."
-              << TORCH_VERSION_MINOR << "."
-              << TORCH_VERSION_PATCH << std::endl;
-    std::cout << std::endl;
-}
-
 int main(int argc, const char *argv[]) {
     if (argc != 2) {
-        std::cerr << "usage: phasm-example-loading-pt <path-to-exported-script-module>\n";
+        std::cerr << "Usage: phasm-example-loading-pt <path-to-exported-script-module>\n";
         return -1;
     }
 
-    auto cuda_available = torch::cuda::is_available();
-    if (not cuda_available) {
-        std::cout << "CUDA device is required for this application!" << std::endl;
+    if (not phasm::has_cuda_device) {
+        std::cout << "CUDA device is required for this example!\n Exit..." << std::endl;
         return -1;
     }
 
-    torch::jit::script::Module module;
+    std::cout << "Run model on CUDA device 0. \n" << std::endl;
+    phasm::get_current_cuda_device_info();
+    phasm::get_libtorch_version();
+
+    // set the device string
+    auto device_str = torch::kCUDA;
+    torch::Device device(device_str);
+
+    std::string pt_name_str = argv[1];
     try {
-        // Deserialize the ScriptModule from a file using torch::jit::load().
-        module = torch::jit::load(argv[1]);
+        phasm::TorchscriptModel cuda_model = phasm::TorchscriptModel(pt_name_str);
     }
     catch (const c10::Error &e) {
         std::cerr << "Error loading the model\n";
         return -1;
     }
-    std::cout << "Loading gluex-tracking-lstm pt model.................... succeed\n\n";
+    std::cout << "Loading gluex-tracking-lstm pytorch pt model.................... succeed\n\n";
 
     /** Test feed-forward computation with an input tensor **/
-    std::cout << "Run model on CUDA device 0." << std::endl;
-    print_cuda_device_info();
-    auto device_str = torch::kCUDA;
-    torch::Device device(device_str);
-
     //the input must be of type std::vector.	
-    std::vector<torch::jit::IValue> inputs;
-    inputs.push_back(torch::ones({1256, 7, 6}, device));  // lstm input dimension
-
-    at::Tensor output = module.forward(inputs).toTensor();
-    std::cout << "output sizes: " << output.sizes() << std::endl;
-    std::cout << "output.device().type(): " << output.device().type() << std::endl;
-    std::cout << output.slice(/*dim=*/0, /*start=*/0, /*end=*/5) << '\n';
+//    std::vector<torch::jit::IValue> inputs;
+//    inputs.push_back(torch::ones({1256, 7, 6}, device));  // lstm input dimension
+//
+//    at::Tensor output = cuda_module.forward(inputs).toTensor();
+//    std::cout << "output sizes: " << output.sizes() << std::endl;
+//    std::cout << "output.device().type(): " << output.device().type() << std::endl;
+//    std::cout << output.slice(/*dim=*/0, /*start=*/0, /*end=*/5) << '\n';
 
     return 0;
 }

--- a/torch_plugin/CMakeLists.txt
+++ b/torch_plugin/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(phasm-torch-plugin SHARED
         src/torch_tensor_utils.cc
         src/feedforward_model.cpp
         src/torchscript_model.cpp
+        src/torch_cuda_utils.cc
         )
 
 set_target_properties(phasm-torch-plugin PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)

--- a/torch_plugin/include/torch_cuda_utils.h
+++ b/torch_plugin/include/torch_cuda_utils.h
@@ -11,8 +11,8 @@
 namespace phasm {
 
     /**
-     * Ask the node whether it has a CUDA device
-     * @return whether the device has CUDA device or not
+     * Ask the node whether it has a CUDA device.
+     * @return whether the device has CUDA device or not.
      */
     bool has_cuda_device();
 

--- a/torch_plugin/include/torch_cuda_utils.h
+++ b/torch_plugin/include/torch_cuda_utils.h
@@ -1,0 +1,30 @@
+//
+// Created by xmei on 1/26/23.
+//
+
+#include <ATen/cuda/CUDAContext.h>  // for cuda device properties
+#include <torch/torch.h>
+
+#ifndef PHASM_TORCH_CUDA_UTILS_H
+#define PHASM_TORCH_CUDA_UTILS_H
+
+namespace phasm {
+
+    /**
+     * Ask the node whether it has a CUDA device
+     * @return whether the device has CUDA device or not
+     */
+    bool has_cuda_device();
+
+    /**
+     * Print current device information: the device name and compute capacity.
+     */
+    void get_current_cuda_device_info();
+
+    /**
+     * Print the libtorch version.
+     */
+    void get_libtorch_version();
+}
+
+#endif //PHASM_TORCH_CUDA_UTILS_H

--- a/torch_plugin/include/torchscript_model.h
+++ b/torch_plugin/include/torchscript_model.h
@@ -31,6 +31,8 @@ public:
 
     bool infer() override;
 
+    at::Tensor forward(std::vector<torch::jit::IValue> inputs);
+
 };
 
 } // namespace phasm

--- a/torch_plugin/src/torch_cuda_utils.cc
+++ b/torch_plugin/src/torch_cuda_utils.cc
@@ -1,0 +1,33 @@
+//
+// Created by xmei on 1/26/23.
+//
+
+#include "torch_cuda_utils.h"
+
+namespace phasm {
+
+    bool has_cuda_device() {
+        auto cuda_available = torch::cuda::is_available();
+        if (not cuda_available) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    void get_current_cuda_device_info() {
+        cudaDeviceProp *cuda_prop = at::cuda::getCurrentDeviceProperties();
+        std::cout << "CUDA device name: " << cuda_prop->name << std::endl;
+        std::cout << "CUDA compute capacity: "
+                  << cuda_prop->major << "." << cuda_prop->minor << std::endl;
+        std::cout << std::endl;
+    }
+
+    void get_libtorch_version() {
+        std::cout << "LibTorch version: "
+                  << TORCH_VERSION_MAJOR << "."
+                  << TORCH_VERSION_MINOR << "."
+                  << TORCH_VERSION_PATCH << std::endl;
+        std::cout << std::endl;
+    }
+}

--- a/torch_plugin/src/torchscript_model.cpp
+++ b/torch_plugin/src/torchscript_model.cpp
@@ -4,11 +4,21 @@
 
 #include "torchscript_model.h"
 #include "torch_tensor_utils.h"
+#include <cassert>
 
 namespace phasm {
 
 TorchscriptModel::TorchscriptModel(std::string filename) {
-    m_module = torch::jit::load(filename);
+    try {
+        m_module = torch::jit::load(filename);
+    }
+    catch (const c10::Error &e) {
+        std::cerr << "Error loading the model. Abort...\n";
+        // TODO： what if having problem loading the model?
+        assert(false);  // manually exit
+        return;
+    }
+    std::cout << "Loading pytorch pt model at [[" << filename <<"]] succeed.\n\n";
 }
 
 TorchscriptModel::~TorchscriptModel() {
@@ -17,6 +27,9 @@ TorchscriptModel::~TorchscriptModel() {
 void TorchscriptModel::initialize() {
 }
 
+at::Tensor TorchscriptModel::forward(std::vector<torch::jit::IValue> inputs) {
+    return m_module.forward(inputs).toTensor();
+}
 
 bool TorchscriptModel::infer() {
 


### PR DESCRIPTION
Modify loading-pt-example to use torch_plugin.
- [x] Add "torch_cuda_utils.h" to include some common CUDA/TORCH helper functions.
- [x] Modify the loading-pt example to use "torchscript_model.h"
- [x] Add TorchscriptModel::forward() to match the use case 



### Test results
Tested on ifarm A100 GPU with singularity container.
```
Singularity> pwd
/w/epsci-sciwork18/xmei/phasm/build

# need to add torch_plugin (/w/epsci-sciwork18/xmei/phasm/build/install/plugins) to path?
Singularity> echo $LD_LIBRARY_PATH 
/deps/libtorch/lib:/usr/lib/x86_64-linux-gnu:/usr/local/cuda/lib64:/usr/local/cuda/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/.singularity.d/libs:/w/epsci-sciwork18/xmei/phasm/build/install/plugins

# build
Singularity> cmake -DCMAKE_PREFIX_PATH="/deps/libtorch;/deps/JANA2/install" -DLIBDWARF_DIR="/deps/libdwarf/installdir"  -DPIN_ROOT="/deps/pin" -DUSE_CUDA=ON ..
Singularity> make -j32 install

# run example
Singularity> ./install/bin/phasm-example-loading-pt /work/epsci/shared_pkg/lstm_model.pt 
Run model on CUDA device 0. 

CUDA device name: NVIDIA A100 80GB PCIe
CUDA compute capacity: 8.0

LibTorch version: 1.13.0

Loading pytorch pt model at [[/work/epsci/shared_pkg/lstm_model.pt]] succeed.

Output sizes: [1256, 6]
Output.device().type(): cuda
 1.0051  0.9764  1.0101  0.9610  0.9754  0.9744
 1.0051  0.9764  1.0101  0.9610  0.9754  0.9744
 1.0051  0.9764  1.0101  0.9610  0.9754  0.9744
 1.0051  0.9764  1.0101  0.9610  0.9754  0.9744
 1.0051  0.9764  1.0101  0.9610  0.9754  0.9744
[ CUDAFloatType{5,6} ]


# error handling
Singularity> ./install/bin/phasm-example-loading-pt /work                      
Run model on CUDA device 0. 

CUDA device name: NVIDIA A100 80GB PCIe
CUDA compute capacity: 8.0

LibTorch version: 1.13.0

Error loading the model. Abort...
phasm-example-loading-pt: /w/epsci-sciwork18/xmei/phasm/torch_plugin/src/torchscript_model.cpp:18: phasm::TorchscriptModel::TorchscriptModel(std::string): Assertion `false' failed.
Aborted

```

---
### Notes
@nathanwbrei 
- Need to manually add  `<...>/phasm/build/install/plugins` to `$LD_LIBRARY_PATH`. Is there a better way to handle this?
- How to handle the loading model error? Currently I abort the program by `assert(false)`. Is there a better way? 