### PR TITLE
Update torch-plugin tests and TorchscriptModel::infer()

### DIFF
--- a/examples/pinn_pde_solver/pinn_diffusion_pde_solver.cpp
+++ b/examples/pinn_pde_solver/pinn_diffusion_pde_solver.cpp
@@ -205,7 +205,7 @@ int main() {
      */
     // Device
     bool has_gpu = phasm::has_cuda_device();
-    auto device_str = (has_gpu == true) ? torch::kCUDA : torch::kCPU;
+    auto device_str = has_gpu? torch::kCUDA : torch::kCPU;
     torch::Device device(device_str);
 
     if (has_gpu) {

--- a/python/magfieldmap_nn.py
+++ b/python/magfieldmap_nn.py
@@ -1,16 +1,14 @@
 import pandas as pd
 import numpy as np
 import torch
-import torchvision
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim 
-from torchvision.transforms import transforms
 from torch.utils.data import DataLoader
 from torch.utils.data import Dataset
-from sklearn.model_selection import train_test_split
 import matplotlib.pyplot as plt
 import csv
+
 # read the data
 def get_device():
     device = 'cpu'

--- a/python/model.py
+++ b/python/model.py
@@ -2,8 +2,6 @@ import torch
 import torch.nn as nn
 import matplotlib.pyplot as plt
 import numpy as np
-import torchvision
-import torchvision
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")  # checking device to use CUDA
 N = nn.Sequential(

--- a/torch_plugin/src/torchscript_model.cpp
+++ b/torch_plugin/src/torchscript_model.cpp
@@ -66,10 +66,10 @@ bool TorchscriptModel::infer() {
         }
 
         // This all assumes a single Tensor of floats as input and output
-        torch::Tensor input = flatten_and_join(input_tensors).to(m_device); // loocated on m_device
+        torch::Tensor input = flatten_and_join(input_tensors).to(m_device); // located on m_device
         std::vector<torch::jit::IValue> inputs;
         inputs.push_back(input);
-        auto output = m_module.forward(inputs).toTensor().to(torch::kCPU);  // oon CPU
+        auto output = m_module.forward(inputs).toTensor().to(torch::kCPU);  // on CPU
 
         std::vector<torch::Tensor> output_tensors = split_and_unflatten_outputs(output, m_output_lengths, m_output_shapes);
 

--- a/torch_plugin/test/pytorch_tests.cpp
+++ b/torch_plugin/test/pytorch_tests.cpp
@@ -2,7 +2,7 @@
 // Copyright 2022, Jefferson Science Associates, LLC.
 // Subject to the terms in the LICENSE file found in the top-level directory.
 
-#define CATCH_CONFIG_MAIN
+
 #include <catch.hpp>
 #include <optics.h>
 #include <torch/torch.h>

--- a/torch_plugin/test/pytorch_tests.cpp
+++ b/torch_plugin/test/pytorch_tests.cpp
@@ -79,6 +79,4 @@ TEST_CASE("Getting a multidimensional array out of a Torch tensor with arbitrary
     std::cout << mat[1][0] << " " << mat[1][1] << " " << mat[1][2] << std::endl;
 }
 
-
-
 }

--- a/torch_plugin/test/torchscript_model_tests.cpp
+++ b/torch_plugin/test/torchscript_model_tests.cpp
@@ -99,15 +99,14 @@ TEST_CASE("Load the module to assigned device (GPU prefered) and do inference") 
         .local_primitive<double>("Bz", Direction::OUT)
         .finish();
 
-    // Set up a simple function pretending to be a magnetic field map data
     double x = 1.0, y = 2.0, z = 3.0, Bx, By, Bz;
     s.bind_original_function([&]() { Bx = -x, By = -y; Bz = -z; });
     s.bind_all_callsite_vars(&x, &y, &z, &Bx, &By, &Bz);
 
-    // Inference results
     s.call_model_and_capture();
     REQUIRE(Bx != -1.0);
     REQUIRE(By != -2.0);
     REQUIRE(Bz != -3.0);
 }
+
 } // namespace phasm::test::torchscript_model_tests

--- a/torch_plugin/test/torchscript_model_tests.cpp
+++ b/torch_plugin/test/torchscript_model_tests.cpp
@@ -1,44 +1,86 @@
+/*
+Copyright 2022-2023, Jefferson Science Associates, LLC.
+Subject to the terms in the LICENSE file found in the top-level directory.
+Authors: Nathan Brei (nbrei@jlab.org), Xinxin Mei (xmei@jlab.org)
+*/
 
-// Copyright 2022-2023, Jefferson Science Associates, LLC.
-// Subject to the terms in the LICENSE file found in the top-level directory.
-// Authors: Nathan Brei (nbrei@jlab.org)
+// Launch this test by  phasm-torch-plugin-tests -p <path-to-mfield-pt-model>
 
+// Make sure to remove the CATCH_CONFIG_MAIN macro from all other test files in your project 
+// to avoid the multiple definition error.
+#define CATCH_CONFIG_RUNNER  // this is necessary because of own-defined main function
 #include <catch.hpp>
+#include <string>
 
 #include <surrogate_builder.h>
 #include "torchscript_model.h"
 
 using namespace phasm;
+
+std::string ptPath;  // global variable taken from command line input
+
+int main(int argc, char* argv[]) {
+    Catch::Session session; // There must be exactly one instance
+
+    // Build a new parser on top of Catch2's
+    using namespace Catch::clara;
+    auto cli
+    = session.cli()           // Get Catch2's command line parser
+    | Opt( ptPath, "path" ) // bind variable to a new option, with a hint string
+        ["-p"]["--path"]    // the option names it will respond to
+        ("Location to the mfield torchscript model");  // description string for the help output
+
+    // Now pass the new composite back to Catch2 so it uses that
+    session.cli( cli );
+
+    // Let Catch2 (using Clara) parse the command line
+    int returnCode = session.applyCommandLine( argc, argv );
+    if( returnCode != 0 ) // Indicates a command line error
+        return returnCode;
+
+    // std::cout << "Module path: " << ptPath << std::endl;
+
+    return session.run();
+}
+
+/**
+ * Test the input module is related to mfield example
+*/
+TEST_CASE("Module has 'mfield' in its name") {
+    REQUIRE(ptPath.find("mfield") != std::string::npos);
+}
+
 namespace phasm::test::torchscript_model_tests {
 
-TEST_CASE("TorchScriptModelTests") {
-
-    // Note that we shouldn't use set_model("phasm-torch-plugin","") here because of the one-definition rule!!!
+/**
+ * Test loading a torchscript model and do one round of inference.
+*/
+TEST_CASE("Load the module to CPU and do inference") {
     auto s = SurrogateBuilder()
-            .set_model(std::make_shared<TorchscriptModel>(""))
-            .local_primitive<double>("p", IN)
-            .local_primitive<double>("theta", IN)
-            .local_primitive<double>("E_abs", OUT)
-            .local_primitive<double>("E_gap", OUT)
-            .finish();
+        .set_model(std::make_shared<TorchscriptModel>(TorchscriptModel(ptPath)), true)
+        .local_primitive<double>("x", phasm::IN)
+        .local_primitive<double>("y", phasm::IN)
+        .local_primitive<double>("z", phasm::IN)
+        .local_primitive<double>("Bx", Direction::OUT)
+        .local_primitive<double>("By", Direction::OUT)
+        .local_primitive<double>("Bz", Direction::OUT)
+        .finish();
 
-    // Set up a simple function pretending to be a sampling calorimeter simulation
-    double p, theta, E_abs, E_gap;
-    s.bind_original_function([&]() { E_abs = p*p; E_gap = p+theta; });
-    s.bind_all_callsite_vars(&p, &theta, &E_abs, &E_gap);
+    // Set up a simple function pretending to be a magnetic field map data
+    double x = 1.0, y = 2.0, z = 3.0, Bx, By, Bz;
+    s.bind_original_function([&]() { Bx = -x, By = -y; Bz = -z; });
+    s.bind_all_callsite_vars(&x, &y, &z, &Bx, &By, &Bz);
 
-    p = 3.0;
-    theta = 2.0;
     s.call_original_and_capture();
-    REQUIRE(E_abs == 9.0);
-    REQUIRE(E_gap == 5.0);
+    REQUIRE(Bx == -1.0);
+    REQUIRE(By == -2.0);
+    REQUIRE(Bz == -3.0);
 
-    p = 5.0;
-    theta = 3.0;
-    s.call_model();
-    // The model isn't trained, so it updates the final values with garbage
-    // The important thing is simply that it updates the values
-    REQUIRE(E_abs != 9.0);
-    REQUIRE(E_gap != 5.0);
+    // Inference results
+    s.call_model_and_capture();
+    REQUIRE(Bx != -1.0);
+    REQUIRE(By != -2.0);
+    REQUIRE(Bz != -3.0);
 }
+
 } // namespace phasm::test::torchscript_model_tests


### PR DESCRIPTION
- Make TorchscriptModel::infer() device tolerant: load the model to the assigned device, inference on the assigned device, copy the output back to CPU
- Add a test case for torch-plugin test and update the original test context. Make this test work with mfield model (of 3 features).

Issue #33 

Test on ifarm gpu container and docker-cpu container.