### PR TITLE
Add benchmarking feature to loading-pt example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ cmake-build*/
 *.pyc
 .DS_Store
 *.pt*
+*.txt
 downloads
 
 # VS code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,8 @@ message(STATUS "USE_CUDA    ${USE_CUDA}")
 option(USE_TORCH "Compile with Torch dependency" ON)
 message(STATUS "USE_TORCH   ${USE_TORCH}")
 
-option(USE_REST "Compile with REST dependency" ON)
-message(STATUS "USE_REST   ${USE_REST}")
+option(USE_REST "Compile with REST dependency" OFF)
+message(STATUS "USE_REST    ${USE_REST}")
 
 option(USE_JULIA "Compile with Julia dependency" OFF)
 message(STATUS "USE_JULIA   ${USE_JULIA}")
@@ -95,7 +95,6 @@ if (${USE_REST})
     find_package(cpprestsdk REQUIRED)
     message(STATUS "Found package REST => ${REST_DIR}")
 endif()
-
 
 if (${USE_GEANT4})
     find_package(Geant4 REQUIRED)

--- a/examples/loading_pt/loading_pt.cpp
+++ b/examples/loading_pt/loading_pt.cpp
@@ -15,9 +15,36 @@
 
 #include <iostream>
 #include <memory>
+#include <chrono>
+#include <cmath>
 
-# define BATCH_SIZE 2048
-# define SEQ_LENGTH 7  // For the test lstm_model.pt model only
+# define MIN_BATCH_SIZE 64
+# define MAX_BATCH_SIZE 16384
+# define DEMO_BATCH_SIZE 2048
+# define DEMO_SEQ_LENGTH 7  // For the test lstm_model.pt model only
+
+/// @brief Measure the elaspsed time of the process of (input initilization + single round inference).
+/// @param input_shape the dimension of the input shape.
+/// @return duration of the process in milliseconds (10e-3 s).
+double benchmark(const std::vector<int64_t>& input_shape, bool use_gpu, phasm::TorchscriptModel& model) {
+    torch::Device bench_device = use_gpu ? torch::kCUDA : torch::kCPU;
+
+    auto t_start = std::chrono::high_resolution_clock::now();
+
+    std::vector<torch::jit::IValue> input;
+    input.push_back(torch::randn(input_shape, bench_device));
+
+    at::Tensor output = model.get_module().forward(input).toTensor();
+    // Operate on the first element of the output to make sure inference execution is completed.
+    // std::cout << output.slice(/*dim=*/0, /*start=*/0, /*end=*/1) << '\n';
+    float firstElement = output[0][0].item<float>();
+    firstElement += 1.0;
+
+    auto t_end = std::chrono::high_resolution_clock::now();
+    auto t_duration = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
+
+    return double(t_duration) / 1000.0;  // return in milliseconds
+}
 
 int main(int argc, const char *argv[]) {
     if (argc != 2) {
@@ -27,12 +54,8 @@ int main(int argc, const char *argv[]) {
 
     phasm::get_libtorch_version();
 
-    bool has_gpu = phasm::has_cuda_device();
-    torch::Device device= torch::kCPU;
-    if (has_gpu) {
-        std::cout << "Use CUDA device 0 to load module!\n" << std::endl;
-        device = torch::kCUDA;
-    }
+    /** FIRST RD: demo functionality on CPU */
+    torch::Device device = torch::kCPU;
 
     /* Load module to the assigned device */
     phasm::TorchscriptModel model = phasm::TorchscriptModel(argv[1], true, device);
@@ -40,11 +63,11 @@ int main(int argc, const char *argv[]) {
     /* Get the input layer information and claim the input based on device */
     std::vector<int64_t> first_layer_shape = model.GetFirstLayerShape();
 
-    // Caculate the input dimension, based on first layer weight matrix shape.
+    // Caculate the input dimension, based on first layer's weight matrix shape.
     // TODO (@xmei): below method is for RNN layer only. Different for nn.linear and nn.conv.
     std::vector<int64_t> input_shape;
-    input_shape.push_back(BATCH_SIZE);
-    input_shape.push_back(SEQ_LENGTH);
+    input_shape.push_back(DEMO_BATCH_SIZE);
+    input_shape.push_back(DEMO_SEQ_LENGTH);
     std::copy(first_layer_shape.begin() + 1, first_layer_shape.end(), std::back_inserter(input_shape));
     std::cout << "Input dimension: " << input_shape << std::endl;
 
@@ -58,5 +81,24 @@ int main(int argc, const char *argv[]) {
     std::cout << "Output.device().type(): " << output.device().type() << std::endl;
     std::cout << output.slice(/*dim=*/0, /*start=*/0, /*end=*/5) << '\n';
 
+    /** BENCHMARKING ON CPU*/
+    std::cout << "\n\n########################################\n";
+    std::cout << "Benchmarking on CPU \n";
+    std::cout << "########################################\n";
+    std::cout << "batch_size,\ttime (milli-seconds)\n";
+    for (int64_t batch_size = MIN_BATCH_SIZE; batch_size <= MAX_BATCH_SIZE; batch_size *= 2) {
+        input_shape.clear();
+        input_shape.push_back(batch_size);
+        input_shape.push_back(DEMO_SEQ_LENGTH);
+        std::copy(first_layer_shape.begin() + 1, first_layer_shape.end(), std::back_inserter(input_shape));
+
+        std::cout << batch_size << ",\t" << benchmark(input_shape, false, model) << std::endl;
+    }
+
+    // bool has_gpu = phasm::has_cuda_device();
+    // if (has_gpu) {
+    //     std::cout << "Use CUDA device 0 to load module!\n" << std::endl;
+    //     device = torch::kCUDA;
+    // }
     return 0;
 }


### PR DESCRIPTION
For lstm-model, the benchmarking result on an ifarm A100 GPU is as

```
# A100 GPU
Batch_size, milliseconds
64, 1174.22  #(overhead here)
128, 46.275  #(no overhead for the following batch size)
256, 29.86
512, 28.476
1024, 28.596
2048, 30.277
4096, 32.544
8192, 34.939
16384, 43.256
```

```
#ifarm same node cpu perf
Batch_size, milliseconds
64, 50.04
128, 30.144
256, 31.59
512, 35.309
1024, 41.215
2048, 53.401
4096, 75.51
8192, 116.027
16384, 194.503
```